### PR TITLE
Add support for v2 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Ruby2.0 or higher
 
 
 ## Usage 
-###Argument without crawl_id
+###Argument without crawl_id(V1 API)
 If you don't specify the crawl_id option, the latest crawl_id is used for scan.
 
 Usage: ruby vaddy.rb auth_key username(LoginID)  hostname
@@ -19,26 +19,27 @@ Usage: ruby vaddy.rb auth_key username(LoginID)  hostname
     ruby vaddy.rb 123455667789  ichikaway  www.examplevaddy.net 
 
 
-###Argument with the crawl_id
+###Argument with the crawl_id(V1 API)
 
 Usage: ruby vaddy.rb auth_key username(LoginID)  hostname crawl_id(optional)
 
     ruby vaddy.rb 123455667789  ichikaway  www.examplevaddy.net 30
 
 
-###Argument with the crawl label keyword
+###Argument with the crawl label keyword(V1 API)
 
 Usage: ruby vaddy.rb auth_key username(LoginID)  hostname crawl_label_keyword
 
     ruby vaddy.rb 123455667789  ichikaway  www.examplevaddy.net useredit
 
 
-### ENV
+### ENV(V1, V2 API)
 export VADDY_TOKEN="123455667789"  
 export VADDY_USER="ichikaway"  
-export VADDY_HOST="www.examplevaddy.com"  
-export VADDY_CRAWL="30"  
+export VADDY_HOST="www.examplevaddy.com" # for V1 API 
+export VADDY_PROJECT_ID="your project id" # for V2 API
+export VADDY_CRAWL_ID="30"  
 
 ruby vaddy.rb
 
-VADDY_CRAWL is optional. If you don't specify it, VAddy uses the latest crawl data.
+VADDY_CRAWL_ID is optional. If you don't specify it, VAddy uses the latest crawl data.


### PR DESCRIPTION
I added support for V2 API at this PR. I confirmed this PR works well.

### Ruby version

```
$ ruby -v
ruby 2.0.0p648 (2015-12-16 revision 53162) [x86_64-darwin17.6.0]
```

### V1 with arguments

```
$ ruby vaddy.rb API_TOKEN USER FQDN
== Start Scan ==
scanning ... 1
----ERROR----
Server : FQDN
Status : finish
Vulnerabilities: 5
Report URL : https://console.vaddy.net/scan_status/xxxx/xxxx-xxxx-xxxx-xxxx
```

### V1 with arguments + crawl_id

```
$ ruby vaddy.rb API_TOKEN USER FQDN crawl-1
== Start Scan ==
----ERROR----
Server : FQDN
Status : finish
Vulnerabilities: 1
Report URL : https://console.vaddy.net/scan_status/xxxx/xxxx-xxxx-xxxx-xxxx
```

### V1 with environment variables

```
$ env | grep VA
VADDY_USER=USER
VADDY_TOKEN=API_TOKEN
VADDY_HOST=FQDN

$ ruby vaddy.rb
== Start Scan ==
scanning ... 1
----ERROR----
Server : FQDN
Status : finish
Vulnerabilities: 5
Report URL : https://console.vaddy.net/scan_status/xxxx/xxxx-xxxx-xxxx-xxxx
```

### V2 with environment variables

```
$ env | grep VA
VADDY_USER=USER
VADDY_TOKEN=API_TOKEN
VADDY_PROJECT_ID=PROJECT_ID

$ ruby vaddy.rb
== Start Scan ==
scanning ... 1
----ERROR----
Server :
Status : finish
Vulnerabilities: 5
Report URL : https://console.vaddy.net/scan_status/xxxx/xxxx-xxxx-xxxx-xxxx
```

### V2 with environment variables(+VADDY_CRAWL_ID)

```
$ env | grep VA
VADDY_USER=USER
VADDY_TOKEN=API_TOKEN
VADDY_PROJECT_ID=PROJECT_ID
VADDY_CRAWL_ID=crawl-1

$ ruby vaddy.rb
== Start Scan ==
----ERROR----
Server :
Status : finish
Vulnerabilities: 1
Report URL : https://console.vaddy.net/scan_status/xxxx/xxxx-xxxx-xxxx-xxxx
```